### PR TITLE
Add cmath header to mat.cpp

### DIFF
--- a/modules/matrix/mat/mat.cpp
+++ b/modules/matrix/mat/mat.cpp
@@ -20,6 +20,7 @@
 #include "dsps_math.h"
 #include "dspm_mult.h"
 #include <math.h>
+#include <cmath>
 
 
 using std::ostream;


### PR DESCRIPTION
std::abs function requires the cmath header

Fixes #8 