### PR TITLE
Fix: use cmath instead of math.h in mat.cpp

### DIFF
--- a/modules/matrix/mat/mat.cpp
+++ b/modules/matrix/mat/mat.cpp
@@ -19,7 +19,7 @@
 
 #include "dsps_math.h"
 #include "dspm_mult.h"
-#include <math.h>
+#include <cmath>
 
 
 using std::ostream;


### PR DESCRIPTION
With math.h the compiler does not know which implementation to choose when abs() is called with a float.

The error message seen during compilation:
../components/esp-dsp/modules/matrix/mat/mat.cpp:288:37: error: 'abs' is not a member of 'std'
             while ((k < A.cols) && (std::abs(A(j,k)) > abs_tol)) {
                                     ^
../components/esp-dsp/modules/matrix/mat/mat.cpp:288:37: note: suggested alternative:
In file included from /espressif_sdk/esp-adf/esp-idf/components/newlib/include/wchar.h:4:0,
                 from /opt/esp/tools/xtensa-esp32-elf/1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/cwchar:44,
                 from /opt/esp/tools/xtensa-esp32-elf/1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/postypes.h:40,
                 from /opt/esp/tools/xtensa-esp32-elf/1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/char_traits.h:40,
                 from /opt/esp/tools/xtensa-esp32-elf/1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/string:40,
                 from /opt/esp/tools/xtensa-esp32-elf/1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/stdexcept:39,
                 from ../components/esp-dsp/modules/matrix/mat/mat.cpp:16:
/espressif_sdk/esp-adf/esp-idf/components/newlib/include/stdlib.h:72:12: note:   'abs'
 int _EXFUN(abs,(int));
            ^