### PR TITLE
Fixed point overflow in init

### DIFF
--- a/modules/fft/fixed/dsps_fft2r_sc16_ansi.c
+++ b/modules/fft/fixed/dsps_fft2r_sc16_ansi.c
@@ -92,11 +92,11 @@ esp_err_t dsps_fft2r_init_sc16(int16_t* fft_table_buff, int table_size)
         dsps_fft2r_sc16_mem_allocated = 1;
     }
 
-    result = dsps_gen_w_r2_sc16(dsps_fft_w_table_sc16, CONFIG_DSP_MAX_FFT_SIZE);
+    result = dsps_gen_w_r2_sc16(dsps_fft_w_table_sc16, dsps_fft_w_table_size);
     if (result != ESP_OK) {
         return result;
     }
-    result = dsps_bit_rev_sc16_ansi(dsps_fft_w_table_sc16, CONFIG_DSP_MAX_FFT_SIZE >> 1);
+    result = dsps_bit_rev_sc16_ansi(dsps_fft_w_table_sc16, dsps_fft_w_table_size >> 1);
     if (result != ESP_OK) {
         return result;
     }

--- a/modules/fft/float/dsps_fft2r_fc32_ansi.c
+++ b/modules/fft/float/dsps_fft2r_fc32_ansi.c
@@ -51,11 +51,11 @@ esp_err_t dsps_fft2r_init_fc32(float* fft_table_buff, int table_size)
         dsps_fft2r_mem_allocated = 1;
     }
 
-    result = dsps_gen_w_r2_fc32(dsps_fft_w_table_fc32, CONFIG_DSP_MAX_FFT_SIZE);
+    result = dsps_gen_w_r2_fc32(dsps_fft_w_table_fc32, table_size);
     if (result != ESP_OK) {
         return result;
     }
-    result = dsps_bit_rev_fc32_ansi(dsps_fft_w_table_fc32, CONFIG_DSP_MAX_FFT_SIZE >> 1);
+    result = dsps_bit_rev_fc32_ansi(dsps_fft_w_table_fc32, table_size >> 1);
     if (result != ESP_OK) {
         return result;
     }

--- a/modules/fft/test/test_dsps_fft2r_fc32_ansi.c
+++ b/modules/fft/test/test_dsps_fft2r_fc32_ansi.c
@@ -41,11 +41,11 @@ TEST_CASE("dsps_fft2r_fc32_ansi functionality", "[dsps]")
         return;
     }
 
-    dsps_fft2r_fc32_ansi(data, N);
     unsigned int start_b = xthal_get_ccount();
+    dsps_fft2r_fc32_ansi(data, N);
+	unsigned int end_b = xthal_get_ccount();
     dsps_bit_rev_fc32_ansi(data, N);
-    unsigned int end_b = xthal_get_ccount();
-
+    
     float min = 10000;
     float max = -10000;
     int max_pos = 0;

--- a/modules/fft/test/test_dsps_fft2r_sc16_ae32.c
+++ b/modules/fft/test/test_dsps_fft2r_sc16_ae32.c
@@ -43,11 +43,10 @@ TEST_CASE("dsps_fft2r_sc16_ae32 functionality", "[dsps]")
         return;
     }
 
+	unsigned int start_b = xthal_get_ccount();
     dsps_fft2r_sc16_ae32(data, N);
-    unsigned int start_b = xthal_get_ccount();
+    unsigned int end_b = xthal_get_ccount();	
     dsps_bit_rev_sc16_ansi(data, N);
-    unsigned int end_b = xthal_get_ccount();
-
 
     for (int i=0 ; i< N ; i++)
     {

--- a/modules/fft/test/test_dsps_fft2r_sc16_ansi.c
+++ b/modules/fft/test/test_dsps_fft2r_sc16_ansi.c
@@ -43,11 +43,10 @@ TEST_CASE("dsps_fft2r_sc16_ansi functionality", "[dsps]")
         return;
     }
 
+	unsigned int start_b = xthal_get_ccount();
     dsps_fft2r_sc16_ansi(data, N);
-    unsigned int start_b = xthal_get_ccount();
+	unsigned int end_b = xthal_get_ccount();
     dsps_bit_rev_sc16_ansi(data, N);
-    unsigned int end_b = xthal_get_ccount();
-
 
     for (int i=0 ; i< N ; i++)
     {


### PR DESCRIPTION
I think there is a big fat mistake in the fixed point init when user provides the buffer for sin/cos value with a lenght that is less than the compile-time default max fft len. 

In addition, if you look into dsps_dotprod.h
```
#ifdef CONFIG_DSP_OPTIMIZED
#define dsps_dotprod_s16 dsps_dotprod_s16_ae32
#define dsps_dotprod_f32 dsps_dotprod_f32_ae32
#define dsps_dotprode_f32 dsps_dotprode_f32_ae32
#endif
#ifdef CONFIG_DSP_ANSI
#define dsps_dotprod_s16 dsps_dotprod_s16_ansi
#define dsps_dotprod_f32 dsps_dotprod_f32_ansi
#define dsps_dotprode_f32 dsps_dotprode_f32_ansi
#endif
```
Then DSP_ANSI and DSP_OPTIMIZED are not exclusive, but in Kconfig, you have
```
config DSP_ANSI
   bool "ANSI C"
config DSP_OPTIMIZED
   bool "ESP32 Optimized"
endchoice

config DSP_OPTIMIZATION
   int
   default 0 if DSP_ANSI
   default 1 if DSP_OPTIMIZED
```
Which means that DSP_ANSI is always defined so you end up in dsps_dotprod_s16 always pointing to the ansi version :-(
