### PR TITLE
Migration to IDF 5.0

### DIFF
--- a/modules/common/include/dsp_common.h
+++ b/modules/common/include/dsp_common.h
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include "dsp_err.h"
 #include "esp_idf_version.h"
-#include "soc/cpu.h"
+#include "esp_cpu.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/modules/common/include/dsp_platform.h
+++ b/modules/common/include/dsp_platform.h
@@ -15,7 +15,7 @@
 
 #ifndef dsp_platform_h_
 #define dsp_platform_h_
-#include "soc/cpu.h"
+#include "esp_cpu.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/portable.h"


### PR DESCRIPTION
According to [official docs](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/migration-guides/system.html#esp-hw-support) `soc/cpu.h` has been replaced with `esp_cpu.h`. Hence the commit.