### PR TITLE
Fix pointer formatting causing -fpermissive error (DSP-77)

### DIFF
--- a/modules/matrix/mat/mat.cpp
+++ b/modules/matrix/mat/mat.cpp
@@ -64,7 +64,7 @@ Mat::Mat()
 
 Mat::~Mat()
 {
-    ESP_LOGD("Mat", "~Mat(%i, %i), ext_buff=%i, data=0x%8.8x", this->rows, this->cols, this->ext_buff, (uint32_t)this->data);
+    ESP_LOGD("Mat", "~Mat(%i, %i), ext_buff=%i, data=%p", this->rows, this->cols, this->ext_buff, this->data);
     if (false == this->ext_buff) {
         delete data;
     }
@@ -623,7 +623,7 @@ void Mat::allocate()
     this->ext_buff = false;
     this->length = this->rows * this->cols;
     data = new float[this->length];
-    ESP_LOGD("Mat", "allocate(%i) = 0x%8.8x", this->length, (uint32_t)this->data);
+    ESP_LOGD("Mat", "allocate(%i) = %p", this->length, this->data);
 }
 
 Mat Mat::expHelper(const Mat &m, int num)


### PR DESCRIPTION
This error is printed when compiling for Linux with `gcc (GCC) 11.2.0`:

```
esp-dsp/modules/matrix/mat/mat.cpp:625:61: warning: cast from ‘float*’ to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
  625 |     ESP_LOGD("Mat", "allocate(%i) = 0x%8.8x", this->length, (uint32_t)this->data);
      |                                                             ^~~~~~~~~~~~~~~~~~~~
```

The declaration of data is `float *data`, so `%p` should be used when printing it.
