### PR TITLE
Support build on Linux target (DSP-159)

### DIFF
--- a/modules/common/include/dsp_common.h
+++ b/modules/common/include/dsp_common.h
@@ -19,10 +19,12 @@
 #include "dsp_err.h"
 #include "esp_idf_version.h"
 
+#if defined(__XTENSA__) || defined(__riscv)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
 #include "esp_cpu.h"
 #else
 #include "soc/cpu.h"
+#endif
 #endif
 
 #ifdef __cplusplus
@@ -70,6 +72,7 @@ esp_err_t tie_log(int n_regs, ...);
 #endif
 
 // esp_cpu_get_ccount function is implemented in IDF 4.1 and later
+#if defined(__XTENSA__) || defined(__riscv)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #define dsp_get_cpu_cycle_count  esp_cpu_get_cycle_count
 #else
@@ -79,5 +82,9 @@ esp_err_t tie_log(int n_regs, ...);
 #define dsp_get_cpu_cycle_count  xthal_get_ccount
 #endif
 #endif // ESP_IDF_VERSION
-
+#else
+// Linux Target
+#include <x86intrin.h>
+#define dsp_get_cpu_cycle_count  __rdtsc
+#endif
 #endif // _dsp_common_H_

--- a/modules/common/include/dsp_platform.h
+++ b/modules/common/include/dsp_platform.h
@@ -16,10 +16,13 @@
 #ifndef dsp_platform_h_
 #define dsp_platform_h_
 #include "esp_idf_version.h"
+
+#if defined(__XTENSA__) || defined(__riscv)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
 #include "esp_cpu.h"
 #else
 #include "soc/cpu.h"
+#endif
 #endif
 
 #include "freertos/FreeRTOS.h"

--- a/modules/conv/float/dsps_ccorr_f32_ansi.c
+++ b/modules/conv/float/dsps_ccorr_f32_ansi.c
@@ -42,8 +42,8 @@ esp_err_t dsps_ccorr_f32_ansi(const float *Signal, const int siglen, const float
     }
 
     for (int n = 0; n < lkern; n++) {
-        size_t k;
-        size_t kmin = lkern - 1 - n;
+        int k;
+        int kmin = lkern - 1 - n;
         corrvout[n] = 0;
 
         for (k = 0; k <= n; k++) {
@@ -52,7 +52,7 @@ esp_err_t dsps_ccorr_f32_ansi(const float *Signal, const int siglen, const float
         ESP_LOGV(TAG, "L1 k = %i, n = %i , kmin= %i, kmax= %i", 0, n, kmin, kmin + n);
     }
     for (int n = lkern; n < lsig; n++) {
-        size_t kmin, kmax, k;
+        int kmin, kmax, k;
 
         corrvout[n] = 0;
 
@@ -65,7 +65,7 @@ esp_err_t dsps_ccorr_f32_ansi(const float *Signal, const int siglen, const float
     }
 
     for (int n = lsig; n < lsig + lkern - 1; n++) {
-        size_t kmin, kmax, k;
+        int kmin, kmax, k;
 
         corrvout[n] = 0;
 

--- a/modules/conv/float/dsps_conv_f32_ansi.c
+++ b/modules/conv/float/dsps_conv_f32_ansi.c
@@ -52,7 +52,7 @@ esp_err_t dsps_conv_f32_ansi(const float *Signal, const int siglen, const float 
         ESP_LOGV(TAG, "L1 kmin = %i, kmax = %i , n-kmin = %i", 0, n, n);
     }
     for (int n = lkern; n < lsig; n++) {
-        size_t kmin, kmax, k;
+        int kmin, kmax, k;
 
         convout[n] = 0;
 
@@ -65,7 +65,7 @@ esp_err_t dsps_conv_f32_ansi(const float *Signal, const int siglen, const float 
     }
 
     for (int n = lsig; n < lsig + lkern - 1; n++) {
-        size_t kmin, kmax, k;
+        int kmin, kmax, k;
 
         convout[n] = 0;
 

--- a/modules/conv/test/test_dsps_ccorr_f32_ae32.c
+++ b/modules/conv/test/test_dsps_ccorr_f32_ae32.c
@@ -45,7 +45,7 @@ TEST_CASE("dsps_ccorr_f32 functionality", "[dsps]")
     }
     dsps_ccorr_f32(inputA, lenA, inputB, lenB, &output[0]);
     dsps_ccorr_f32_ansi(inputA, lenA, inputB, lenB, &output_ref[0]);
-    for (size_t i = 0; i < (lenA + lenB - 1) + 2; i++) {
+    for (int i = 0; i < (lenA + lenB - 1) + 2; i++) {
         ESP_LOGI(TAG, "Data[%i] = %2.2f, expected = %2.2f", i, output[i], output_ref[i]);
     }
     for (size_t i = 0; i < (lenA + lenB - 1) + 2; i++) {

--- a/modules/conv/test/test_dsps_conv_f32_ae32.c
+++ b/modules/conv/test/test_dsps_conv_f32_ae32.c
@@ -54,11 +54,11 @@ TEST_CASE("dsps_conv_f32 test output", "[dsps]")
     dsps_conv_f32_ansi(inputA, la, inputB, lb, &output_ref[1]);
     dsps_conv_f32(inputA, la, inputB, lb, &output_fwd[1]);
 
-    for (size_t i = 0; i < (la + lb + 1); i++) {
+    for (int i = 0; i < (la + lb + 1); i++) {
         ESP_LOGD(TAG, "la=%i, lb=%i, i=%i, ref=%2.3f, fwd=%2.3f", la, lb, i, output_ref[i], output_fwd[i]);
     }
     float max_eps = 0.000001;
-    for (size_t i = 0; i < (la + lb + 1); i++) {
+    for (int i = 0; i < (la + lb + 1); i++) {
         if (fabs(output_ref[i] - output_fwd[i]) > max_eps) {
             ESP_LOGI(TAG, "la=%i, lb=%i, i=%i, ref=%2.3f, fwd=%2.3f", la, lb, i, output_ref[i], output_fwd[i]);
         }
@@ -80,8 +80,8 @@ TEST_CASE("dsps_conv_f32 functionality", "[dsps]")
     float *output_fwd = (float *)memalign(16, (lenA + lenB - 1 + 2) * sizeof(float));
     float *output_back = (float *)memalign(16, (lenA + lenB - 1 + 2) * sizeof(float));
 
-    for (size_t la = 2; la < lenA; la++) {
-        for (size_t lb = 2; lb < lenB; lb++) {
+    for (int la = 2; la < lenA; la++) {
+        for (int lb = 2; lb < lenB; lb++) {
             for (int i = 0 ; i < lenA ; i++) {
                 inputA[i] = (float)rand() / (float)INT32_MAX;
             }
@@ -97,7 +97,7 @@ TEST_CASE("dsps_conv_f32 functionality", "[dsps]")
             dsps_conv_f32(inputA, la, inputB, lb, &output_fwd[1]);
             dsps_conv_f32(inputB, lb, inputA, la, &output_back[1]);
             float max_eps = 0.000001;
-            for (size_t i = 0; i < (la + lb + 1); i++) {
+            for (int i = 0; i < (la + lb + 1); i++) {
                 if ((fabs(output_ref[i] - output_fwd[i]) > max_eps) || (fabs(output_ref[i] - output_back[i]) > max_eps) || (fabs(output_back[i] - output_fwd[i]) > max_eps)) {
                     ESP_LOGI(TAG, "la=%i, lb=%i, i=%i, ref=%2.3f, fwd=%2.3f, back=%2.3f", la, lb, i, output_ref[i], output_fwd[i], output_back[i]);
                 }

--- a/modules/conv/test/test_dsps_conv_f32_ansi.c
+++ b/modules/conv/test/test_dsps_conv_f32_ansi.c
@@ -65,8 +65,8 @@ TEST_CASE("dsps_conv_f32_ansi functionality", "[dsps]")
     float *output_fwd = (float *)memalign(16, (lenA + lenB - 1 + 2) * sizeof(float));
     float *output_back = (float *)memalign(16, (lenA + lenB - 1 + 2) * sizeof(float));
 
-    for (size_t la = 1; la < lenA; la++) {
-        for (size_t lb = 1; lb < lenB; lb++) {
+    for (int la = 1; la < lenA; la++) {
+        for (int lb = 1; lb < lenB; lb++) {
             for (int i = 0 ; i < lenA ; i++) {
                 inputA[i] = (float)rand() / (float)INT32_MAX;
             }
@@ -82,7 +82,7 @@ TEST_CASE("dsps_conv_f32_ansi functionality", "[dsps]")
             dsps_conv_f32_ansi(inputA, la, inputB, lb, &output_fwd[1]);
             dsps_conv_f32_ansi(inputB, lb, inputA, la, &output_back[1]);
             float max_eps = 0.000001;
-            for (size_t i = 0; i < (la + lb + 1); i++) {
+            for (int i = 0; i < (la + lb + 1); i++) {
                 if ((fabs(output_ref[i] - output_fwd[i]) > max_eps) || (fabs(output_ref[i] - output_back[i]) > max_eps) || (fabs(output_back[i] - output_fwd[i]) > max_eps)) {
                     ESP_LOGI(TAG, "la=%i, lb=%i, i=%i, ref=%2.3f, fwd=%2.3f, back=%2.3f", la, lb, i, output_ref[i], output_fwd[i], output_back[i]);
                 }

--- a/modules/conv/test/test_dsps_corr_f32_ae32.c
+++ b/modules/conv/test/test_dsps_corr_f32_ae32.c
@@ -46,7 +46,7 @@ TEST_CASE("dsps_corr_f32_aexx functionality", "[dsps]")
     inputB[0] = 1;
     dsps_corr_f32(inputA, lenA, inputB, lenB, &output[1]);
     dsps_corr_f32_ansi(inputA, lenA, inputB, lenB, &output_ref[1]);
-    for (size_t i = 0; i < (lenA - lenB) + 2; i++) {
+    for (int i = 0; i < (lenA - lenB) + 2; i++) {
         ESP_LOGD(TAG, "Data[%i] = %2.2f, expected = %2.2f", i, output[i], output_ref[i]);
     }
     for (size_t i = 0; i < (lenA - lenB) + 2; i++) {

--- a/modules/conv/test/test_dsps_corr_f32_ansi.c
+++ b/modules/conv/test/test_dsps_corr_f32_ansi.c
@@ -43,7 +43,7 @@ TEST_CASE("dsps_corr_f32_ansi functionality", "[dsps]")
     }
     inputB[0] = 1;
     dsps_corr_f32_ansi(inputA, lenA, inputB, lenB, &output[1]);
-    for (size_t i = 0; i < lenA + lenB; i++) {
+    for (int i = 0; i < lenA + lenB; i++) {
         ESP_LOGD(TAG, "output[%i] = %2.2f", i, output[i]);
     }
 

--- a/modules/dct/test/test_dsps_dct_f32.c
+++ b/modules/dct/test/test_dsps_dct_f32.c
@@ -54,11 +54,11 @@ TEST_CASE("dsps_dct_f32 functionality", "[dsps]")
     dsps_dct_inverce_f32_ref(&data[N], N, data);
     dsps_view(&data[0], 32, 32, 10, -2, 2, '.');
 
-    for (size_t i = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         ESP_LOGD(TAG, "DCT data[%i] = %2.3f\n", i, data[N + i]);
     }
     float abs_tol = 1e-5;
-    for (size_t i = 1; i < N; i++) {
+    for (int i = 1; i < N; i++) {
         ESP_LOGD(TAG, "data[%i] = %f, ref_data = %f\n", i, data[i], data_ref[i]*N / 2);
         float error = fabs(data[i] - data_ref[i] * N / 2) / (N / 2);
         if (error > abs_tol) {
@@ -104,7 +104,7 @@ TEST_CASE("dsps_dct_f32 functionality Fast DCT", "[dsps]")
 
     float abs_tol = 1e-5;
 
-    for (size_t i = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         ESP_LOGD(TAG, "DCT data[%i] = %2.3f, data_fft = %2.3f\n", i, data[N + i], data_fft[i]);
         float error = fabs(data[N + i] - data_fft[i]) / (N / 2);
         if (error > abs_tol) {
@@ -115,7 +115,7 @@ TEST_CASE("dsps_dct_f32 functionality Fast DCT", "[dsps]")
 
     dsps_dct_inv_f32(data_fft, N);
 
-    for (size_t i = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         ESP_LOGD(TAG, "IDCT data[%i] = %2.3f, data_fft = %2.3f\n", i, data[i], data_fft[i] / N * 2);
         float error = fabs(data[i] - data_fft[i] / N * 2) / (N / 2);
         if (error > abs_tol) {

--- a/modules/fft/test/test_dsps_fft4r_fc32_ansi.c
+++ b/modules/fft/test/test_dsps_fft4r_fc32_ansi.c
@@ -151,7 +151,7 @@ TEST_CASE("dsps_cplx2real_fc32 functionality", "[dsps]")
         }
         diff = diff / N_check;
         if (diff > 0.00001) {
-            for (size_t i = 0; i < N_check * 2; i++) {
+            for (int i = 0; i < N_check * 2; i++) {
                 ESP_LOGD(TAG, "data[%i]= %f,    %f = check_data_fft[%i], diff=%f\n", i, data[i], check_data_fft[i], i, data[i] - check_data_fft[i]);
             }
 


### PR DESCRIPTION
1. Avoid include esp_cpu on Linux target
2. Fix warnings regarding size_t v.s. int on Log

## Description

Build support on Linux target.

Fix #85 

## Testing

Verified via test_app.
All cases passed except 
1. matrix reverse test failed due to a slight large calculation error (0.000145 > 1e-4).
```
Error at[3] = 0.000145, expected= -38.000000, calculated = -38.000145
/home/howardsu/esp-dsp/modules/matrix/mul/test/test_mat_sub_f32.cpp:826:Matrix subset methods check:FAIL:Function [dspm].  Error in inverse() operation!\n
```
2. Time Error in 10 cases, which I believe it is due to the difference of cycle tracking. On Linux, I uses rdtsc.
```
Error at[3] = 0.000145, expected= -38.000000, calculated = -38.000145
/home/howardsu/esp-dsp/modules/matrix/mul/test/test_mat_sub_f32.cpp:826:Matrix subset methods check:FAIL:Function [dspm].  Error in inverse() operation!\n
```
## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
