### PR TITLE
Add iFFT function

### DIFF
--- a/modules/fft/float/dsps_fft2r_fc32_ansi.c
+++ b/modules/fft/float/dsps_fft2r_fc32_ansi.c
@@ -37,7 +37,7 @@ extern float *dsps_fft2r_w_table_fc32_1024;
 
 unsigned short reverse(unsigned short x, unsigned short N, int order);
 
-esp_err_t dsps_fft2r_init_fc32(float *fft_table_buff, int table_size)
+esp_err_t dsps_fft2r_init_fc32_(float *fft_table_buff, int table_size, int reverse)
 {
     esp_err_t result = ESP_OK;
     if (dsps_fft2r_initialized != 0) {
@@ -86,7 +86,7 @@ esp_err_t dsps_fft2r_init_fc32(float *fft_table_buff, int table_size)
         dsps_fft2r_rev_tables_fc32[pow - 4] = dsps_fft2r_ram_rev_table;
     }
 
-    result = dsps_gen_w_r2_fc32(dsps_fft_w_table_fc32, dsps_fft_w_table_size);
+    result = dsps_gen_w_r2_fc32(dsps_fft_w_table_fc32, dsps_fft_w_table_size, reverse);
     if (result != ESP_OK) {
         return result;
     }
@@ -199,7 +199,7 @@ esp_err_t dsps_bit_rev_fc32_ansi(float *data, int N)
     return result;
 }
 
-esp_err_t dsps_gen_w_r2_fc32(float *w, int N)
+esp_err_t dsps_gen_w_r2_fc32(float *w, int N, int iFFT)
 {
     if (!dsp_is_power_of_two(N)) {
         return ESP_ERR_DSP_INVALID_LENGTH;
@@ -208,7 +208,12 @@ esp_err_t dsps_gen_w_r2_fc32(float *w, int N)
     esp_err_t result = ESP_OK;
 
     int i;
-    float e = M_PI * 2.0 / N;
+    float e;
+    
+    if (iFFT)
+        e = -M_PI * 2.0 / N;
+    else
+        e = M_PI * 2.0 / N;
 
     for (i = 0; i < (N >> 1); i++) {
         w[2 * i] = cosf(i * e);

--- a/modules/fft/include/dsps_fft2r.h
+++ b/modules/fft/include/dsps_fft2r.h
@@ -58,8 +58,11 @@ extern uint8_t dsps_fft2r_sc16_initialized;
  *      - ESP_ERR_DSP_REINITIALIZED if buffer already allocated internally by other function
  *      - One of the error codes from DSP library
  */
-esp_err_t dsps_fft2r_init_fc32(float *fft_table_buff, int table_size);
+esp_err_t dsps_fft2r_init_fc32_(float *fft_table_buff, int table_size, int reverse_fft);
+#define dsps_fft2r_init_fc32(fft_table_buff, table_size) dsps_fft2r_init_fc32_(fft_table_buff, table_size, 0)
+#define dsps_ifft2r_init_fc32(fft_table_buff, table_size) dsps_fft2r_init_fc32_(fft_table_buff, table_size, 1)
 esp_err_t dsps_fft2r_init_sc16(int16_t *fft_table_buff, int table_size);
+
 /**@}*/
 
 /**@{*/
@@ -154,7 +157,7 @@ esp_err_t dsps_bit_rev_lookup_fc32_aes3(float *data, int reverse_size, uint16_t 
  *      - ESP_OK on success
  *      - One of the error codes from DSP library
  */
-esp_err_t dsps_gen_w_r2_fc32(float *w, int N);
+esp_err_t dsps_gen_w_r2_fc32(float *w, int N, int iFFT);
 esp_err_t dsps_gen_w_r2_sc16(int16_t *w, int N);
 /**@}*/
 

--- a/modules/fft/test/test_dsps_fft2r_fc32_ansi.c
+++ b/modules/fft/test/test_dsps_fft2r_fc32_ansi.c
@@ -82,6 +82,45 @@ TEST_CASE("dsps_fft2r_fc32_ansi functionality", "[dsps]")
     dsps_fft2r_deinit_fc32();
 }
 
+TEST_CASE("dsps_ifft2r_fc32_ansi functionality", "[dsps]")
+{
+    float data[] = {
+        10.0, 0.0,
+        -2.0, 2.0,
+        -2.0, 0.0,
+        -2.0, -2.0,
+    };
+    const float check_data[] = {
+        1.0, 0.0,
+        2.0, 0.0,
+        3.0, 0.0,
+        4.0, 0.0,
+    };
+
+    const int N = 4;
+    dsps_ifft2r_init_fc32(NULL, N);
+
+    unsigned int start_b = dsp_get_cpu_cycle_count();
+    dsps_fft2r_fc32_ansi(data, N);
+    dsps_bit_rev_fc32_ansi(data, N);
+    unsigned int end_b = dsp_get_cpu_cycle_count();
+    dsps_fft2r_deinit_fc32();
+
+    for (int i = 0; i < N; i++)
+    {
+        data[i * 2 + 0] /= N;
+        data[i * 2 + 1] /= N;
+    }
+
+    for (int i = 0; i < N * 2; i++)
+    {
+        //ESP_LOGI(TAG, "ifft2r Data[%i] =%8.4f", i, data[i]);
+        float delta = fabsf(data[i] - check_data[i]);
+        TEST_ASSERT_TRUE(delta < 1e-4);
+    }
+    ESP_LOGI(TAG, "cycles - %i", end_b - start_b);
+}
+
 TEST_CASE("dsps_fft2r_fc32_ansi benchmark", "[dsps]")
 {
     esp_err_t ret = dsps_fft2r_init_fc32(NULL, CONFIG_DSP_MAX_FFT_SIZE);


### PR DESCRIPTION
## Description

Add reverse FFT support.
[Only fc32 as a PR to discuss]

Generate a reverse twiddle table when init. No need to change other logic as FFT. finally rescale the result by 1/N.

Need discussion on API design
1. shall we add additional parameter iFFT to dsps_fft2r_init_fc32, or define a new function
2. Where to put the logic to scale 1/N in iFFT caculation? it can be embedded into dsps_bit_rev_fc32_ansi (also need one more parameter) or a new function

## Related
Fix #62

## Testing

Add a simple test case to test

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
